### PR TITLE
add paper link command

### DIFF
--- a/soh/soh/Enhancements/chaos.cpp
+++ b/soh/soh/Enhancements/chaos.cpp
@@ -9,6 +9,8 @@
 #include <variables.h>
 #undef Polygon
 
+#include "debugconsole.h"
+
 #include <algorithm>
 #include <functional>
 #include <map>
@@ -162,6 +164,13 @@ static std::map<uint8_t, CommandCreator> kCommands {
 	CMD_ONE_SHOT_CVAR(CMD_ID++, "gRestrainLink"),
 	CMD_ONE_SHOT_CVAR(CMD_ID++, "gTripToSpace"),
 	CMD_ONE_SHOT_CVAR(CMD_ID++, "gRedoRando"),
+
+	// Paper link
+	CMD(CMD_ID++, PL_BYTES(sizeof(uint32_t)),
+		CR_ONE_SHOT_TIMED(
+			[&]() { chaosEffectPaperLink = 1; },
+			[&]() { chaosEffectPaperLink = 0; chaosEffectResetLinkScale = 1; })),
+
 	CMD_TIMED_BOOL_CVAR(CMD_ID++, "gAnnoyingText"),
 
 	CMD_TAKE_AMMO(0x80, ITEM_BOMBCHU),

--- a/soh/soh/Enhancements/chaos_commands_macros.h
+++ b/soh/soh/Enhancements/chaos_commands_macros.h
@@ -74,4 +74,6 @@
 
 #define CMD_GIVE_AMMO(id, item, upgrade) CMD_ONE_SHOT(id, PL_BYTES(sizeof(uint32_t)), { uint32_t amt = Read<uint32_t>(payload, 0); AMMO(item) = s_add(AMMO(item), amt, CUR_CAPACITY(upgrade)); })
 
+#define CMD_TIMED_BOOL(id, variable) CMD(id, PL_BYTES(sizeof(uint32_t)), CR_ONE_SHOT_TIMED([&]() { variable = 1; }, [&]() { variable = 0; }))
+
 #endif


### PR DESCRIPTION
this adds a command that utilizes the paper link effect from the built in SoH crowd control commands